### PR TITLE
Configura o padrão de codificação (editorconfig)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf


### PR DESCRIPTION
É o ideal que todos os contribuidores usem o mesmo estilo de codificação, o [EditorConfig](https://editorconfig.org/) é uma maneira de fazer isso.